### PR TITLE
Disable upgrading Perl dependencies

### DIFF
--- a/disable-perl.json
+++ b/disable-perl.json
@@ -7,7 +7,8 @@
         "cpanfile"
       ],
       "matchPackageNames": [
-        "perl"
+        "perl",
+        "List::Util"
       ],
       "enabled": false
     }


### PR DESCRIPTION
Trying to keep List::Utils down at 1.33 because it's the lowest we need for tag-expressions to work, doesn't work, because Renovate keeps coming back with updates to 1.63.  The difference is that 1.63 means that most Perl versions need an updated List::Utils, whereas 1.33 means that almost none of them do (except some very old ones not likely to be used anymore...)
