### PR TITLE
Remove redundant patch automerge configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,6 @@
     ":rebaseStalePrs",
     ":disableDependencyDashboard",
     ":automergeBranch",
-    ":automergePatch",
     ":automergeMinor",
     "github>cucumber/renovate-config:gemspec",
     "github>cucumber/renovate-config:disable-perl"


### PR DESCRIPTION
### 🤔 What's changed?

`automergeMinor` and `automergePatch` are both specified in the default configuration. However, except for the patch option specifying to raise separate pull requests for minor and patch updates, `automergeMinor` covers `automergePatch`. Thus, it may be preferable to extend `automergeMinor` and set `separateMinorPatch` to `true` for the same behaviour; or alternatively drop `separateMinorPatch` if not required.

[:automergeMinor](https://docs.renovatebot.com/presets-default/#automergeminor)

Automerge `patch` and `minor` upgrades if they pass tests.

```json
{
  "lockFileMaintenance": {
    "automerge": true
  },
  "minor": {
    "automerge": true
  },
  "patch": {
    "automerge": true
  },
  "pin": {
    "automerge": true
  }
}
```

[:automergePatch](https://docs.renovatebot.com/presets-default/#automergepatch)
Automerge `patch` upgrades if they pass tests.

```json
{
  "lockFileMaintenance": {
    "automerge": true
  },
  "patch": {
    "automerge": true
  },
  "pin": {
    "automerge": true
  },
  "separateMinorPatch": true
}
```

### ⚡️ What's your motivation? 

Be explicit where we deviate from defaults; and to reduce PRs across the organisation (where separate PRs would be raised to update patch and minor versions).

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is there any particular reason we would want separate pull requests for minor and patch updates? Perhaps that underlying configuration was not considered? Essentially, do we have any particular reason to deviate from the defaults? If so, we need only extend `:automergeMinor`.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
