### PR TITLE
Support cpp/deps.txt

### DIFF
--- a/cpp-deps-txt.json
+++ b/cpp-deps-txt.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Parse cpp/deps.txt files",
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "(^|/)deps\\.txt"
+      ],
+      "matchStrings": [
+        "https://github.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?).zip"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
+  ]
+}

--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
     ":automergeBranch",
     ":automergeMinor",
     "github>cucumber/renovate-config:gemspec",
-    "github>cucumber/renovate-config:disable-perl"
+    "github>cucumber/renovate-config:disable-perl",
+    "github>cucumber/renovate-config:cpp-deps.txt"
   ],
   "prHourlyLimit": 0
 }


### PR DESCRIPTION
### 🤔 What's changed?

Our cpp projects use deps.txt to list and download their dependencies. These should be automatically updated.

This is especially important because floating dependencies may break the build when we don't expect it to. E.g: https://github.com/cucumber/gherkin/pull/206

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
