### PR TITLE
Apply dependencies label to pull requests

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,5 +11,6 @@
     "github>cucumber/renovate-config:disable-perl",
     "github>cucumber/renovate-config:cpp-deps-txt"
   ],
+  "labels": [":robot: dependencies"],
   "prHourlyLimit": 0
 }


### PR DESCRIPTION
### 🤔 What's changed?

- Apply `:robot: dependencies` label to Renovate pull requests

### ⚡️ What's your motivation? 

- Improves filtering of dependencies work - whether by Renovate or developers (applied manually) - making it easier to identify and track that work across repositories
- Prevents manual effort for labelling Renovate pull requests
- Label is a common convention applied by GitHub's dependabot and used across repositories including [gherkin](https://github.com/cucumber/gherkin/pulls?q=is%3Apr+label%3A%22%3Arobot%3A+dependencies%22+is%3Aclosed)
- Follows convention of [Cucumber issue templates](https://github.com/cucumber/.github/tree/main/.github/ISSUE_TEMPLATE) of auto labelling for bugs, enhancements, debt, etc.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

- Is perhaps a point of preference, so open to differing opinion
- If not possible to apply globally, will take guidance whether can be applied to local Renovate configurations across a handful of repositories where the label is being used

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)