### PR TITLE
update go import when updating dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
     ":automergeBranch",
     ":automergeMinor",
     "github>cucumber/renovate-config:gemspec",
+    "github>cucumber/renovate-config:go",
     "github>cucumber/renovate-config:disable-perl",
     "github>cucumber/renovate-config:cpp-deps-txt"
   ],

--- a/go.json
+++ b/go.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Update go imports",
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ]
+}


### PR DESCRIPTION
### 🤔 What's changed?
Modify renovate config to update go imports when updating dependencies

### ⚡️ What's your motivation? 

Currently when renovate runs on `cucumber/gherkin` it does not correctly updates the version of `cucumber/messages`. See https://github.com/cucumber/gherkin/commit/7207024cb9d9bb6a038b68e5e5ac7cdaa3ec20c6 for example. It add only the new version in the go.mod and keeps the old version in both the go.mod and the go files

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
