### PR TITLE
Enable dependency dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,6 @@
     "config:recommended",
     ":preserveSemverRanges",
     ":rebaseStalePrs",
-    ":disableDependencyDashboard",
     ":automergeBranch",
     ":automergeMinor",
     "github>cucumber/renovate-config:gemspec",


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Renovates dependency detection seems to be a bit spotty at times. Enabling the dependency dashboard will allow us to see what dependencies Renovate actually detected.

This will cause some noise by creating a large number of issues, but you can unsubscribe from those issue.
