### PR TITLE
 Widen ranges for selected messages dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,8 @@
     "github>cucumber/renovate-config:gemspec",
     "github>cucumber/renovate-config:go",
     "github>cucumber/renovate-config:disable-perl",
-    "github>cucumber/renovate-config:cpp-deps-txt"
+    "github>cucumber/renovate-config:cpp-deps-txt",
+    "github>cucumber/renovate-config:messages-range-strategy-widen"
   ],
   "labels": [":robot: dependencies"]
 }

--- a/default.json
+++ b/default.json
@@ -4,7 +4,6 @@
     "config:recommended",
     ":preserveSemverRanges",
     ":rebaseStalePrs",
-    ":disableDependencyDashboard",
     ":automergeBranch",
     ":automergeMinor",
     "github>cucumber/renovate-config:gemspec",

--- a/messages-range-strategy-widen.json
+++ b/messages-range-strategy-widen.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Widen ranges for Cucumber Messages, Gherkin and Query dependencies",
+  "packageRules": [
+    {
+      "matchPackageName": [
+        "@cucumber/messages",
+        "cucumber/messages",
+        "cucumber_messages",
+        "io.cucumber:messages"
+      ],
+      "rangeStrategy": "widen"
+    }
+  ]
+}


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Widen ranges for selected messages dependencies

Because messages is distributed in many languages there are quite a few
no-op releases. So to avoid a cascade of releases, the messages
dependency should be used with a version range.

We have to tell Renovate to preserve this range.
