### PR TITLE
Allow updating cucumber npm packages immediately

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,8 @@
     "github>cucumber/renovate-config:gemspec",
     "github>cucumber/renovate-config:go",
     "github>cucumber/renovate-config:disable-perl",
-    "github>cucumber/renovate-config:cpp-deps-txt"
+    "github>cucumber/renovate-config:cpp-deps-txt",
+    "github>cucumber/renovate-config:npm-cucumber-minimum-release-age"
   ],
   "labels": [":robot: dependencies"]
 }

--- a/npm-cucumber-minimum-release-age.json
+++ b/npm-cucumber-minimum-release-age.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "",
+  "packageRules": [
+    {
+      "description": "Do not artificially delay updating npm packages from the cucumber org",
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchDepNames": [
+        "@cucumber/**"
+      ],
+      "minimumReleaseAge": null
+    }
+  ]
+}


### PR DESCRIPTION
### 🤔 What's changed?

Per https://www.mend.io/blog/secure-npm-ecosystem-with-mend-renovate, the "recommended" config we now inherit from has a 3 day minimum age for new dependency versions, designed to avoid supply chain attacks that are usually closed down within 1-2 days.

This PR adds an exemption for our own npm packages - anything under the `@cucumber` org - so that we can have updates move through the dependency tree fairly quickly without lots of manual intervention.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
