### PR TITLE
Enable pinning Github actions to digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     ":rebaseStalePrs",
     ":automergeBranch",
     ":automergeMinor",
+    "helpers:pinGitHubActionDigests",
     "github>cucumber/renovate-config:range-strategy-preserve",
     "github>cucumber/renovate-config:gemspec",
     "github>cucumber/renovate-config:go",


### PR DESCRIPTION
### ⚡️ What's your motivation? 

This ensures that if tags are changed, the actions are not

1. https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
2. https://docs.renovatebot.com/modules/manager/github-actions/
